### PR TITLE
fix: Remove duplicate log

### DIFF
--- a/src/apscheduler/workers/async_.py
+++ b/src/apscheduler/workers/async_.py
@@ -131,7 +131,6 @@ class AsyncWorker:
         finally:
             current_worker.reset(token)
             self._state = RunState.stopped
-            self.logger.exception("Worker crashed")
             with move_on_after(3, shield=True):
                 await self._events.publish(WorkerStopped(exception=exception))
 


### PR DESCRIPTION
When AsyncWorker is stopped normally, after the "Worker stopped" log, there is also a "Worker crashed" log, which should be removed it.